### PR TITLE
Include the network mask in k8s.ovn.org/host-addresses (cont.)

### DIFF
--- a/go-controller/pkg/node/gateway_localnet_linux_test.go
+++ b/go-controller/pkg/node/gateway_localnet_linux_test.go
@@ -2238,7 +2238,7 @@ var _ = Describe("Node Operations", func() {
 				fNPW.watchFactory = fakeOvnNode.watcher
 				Expect(startNodePortWatcher(fNPW, fakeOvnNode.fakeClient, &fakeMgmtPortConfig)).To(Succeed())
 				// to ensure the endpoint is local-host-networked
-				res := fNPW.nodeIPManager.addresses.Has(ep1.Addresses[0])
+				res := fNPW.nodeIPManager.addresses.Has(ep1.Addresses[0] + "/32")
 				Expect(res).To(BeTrue())
 				err := fNPW.AddService(&service)
 				Expect(err).NotTo(HaveOccurred())
@@ -2527,7 +2527,7 @@ var _ = Describe("Node Operations", func() {
 				fNPW.watchFactory = fakeOvnNode.watcher
 				Expect(startNodePortWatcher(fNPW, fakeOvnNode.fakeClient, &fakeMgmtPortConfig)).To(Succeed())
 				// to ensure the endpoint is local-host-networked
-				res := fNPW.nodeIPManager.addresses.Has(endpointSlice.Endpoints[0].Addresses[0])
+				res := fNPW.nodeIPManager.addresses.Has(endpointSlice.Endpoints[0].Addresses[0] + "/32")
 				Expect(res).To(BeTrue())
 				err := fNPW.AddService(&service)
 				Expect(err).NotTo(HaveOccurred())

--- a/go-controller/pkg/node/node_ip_handler_linux_test.go
+++ b/go-controller/pkg/node/node_ip_handler_linux_test.go
@@ -37,7 +37,7 @@ func nodeHasAddress(fakeClient kubernetes.Interface, nodeName string, ipNet *net
 	Expect(err).NotTo(HaveOccurred())
 	addrs, err := util.ParseNodeHostAddresses(node)
 	Expect(err).NotTo(HaveOccurred())
-	return addrs.Has(ipNet.IP.String())
+	return addrs.Has(ipNet.String())
 }
 
 type testCtx struct {


### PR DESCRIPTION
Fix unit tests affected to include mask
